### PR TITLE
Deploy Community Forum to Render

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+node_modules
+vendor
+.env
+.env.*
+!.env.example
+storage/logs/*
+storage/framework/cache/*
+storage/framework/sessions/*
+storage/framework/views/*

--- a/.github/workflows/modernization-checkpoint.yml
+++ b/.github/workflows/modernization-checkpoint.yml
@@ -3,7 +3,8 @@ name: Laravel 12 CI
 on:
   push:
     branches:
-      - portfolio-hardening
+      - master
+      - deploy/render-demo
   pull_request:
     branches:
       - master
@@ -57,3 +58,14 @@ jobs:
 
       - name: Build production assets
         run: npm run build
+
+  render-image:
+    name: Render image build
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Render image
+        run: docker build --pull -f Dockerfile.render -t laravel-community-forum-render .

--- a/Dockerfile.render
+++ b/Dockerfile.render
@@ -1,0 +1,47 @@
+FROM node:24-bookworm-slim AS assets
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --no-fund --no-audit
+COPY vite.config.js ./
+COPY resources ./resources
+COPY public ./public
+RUN npm run build
+
+FROM php:8.2-cli-bookworm
+WORKDIR /app
+
+ENV APP_ENV=production \
+    APP_DEBUG=false \
+    LOG_CHANNEL=stderr \
+    DB_CONNECTION=pgsql \
+    CACHE_DRIVER=file \
+    SESSION_DRIVER=file \
+    QUEUE_CONNECTION=sync
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpq-dev libonig-dev unzip ca-certificates \
+    && docker-php-ext-install pdo_pgsql mbstring \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY composer.json composer.lock ./
+RUN COMPOSER_PROCESS_TIMEOUT=1200 composer install \
+    --no-dev \
+    --no-interaction \
+    --prefer-dist \
+    --no-progress \
+    --no-scripts \
+    --optimize-autoloader
+
+COPY . .
+COPY --from=assets /app/public/build ./public/build
+
+RUN COMPOSER_PROCESS_TIMEOUT=1200 composer dump-autoload --no-dev --optimize \
+    && mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache \
+    && chmod -R ug+rwX storage bootstrap/cache
+
+COPY deploy/render-start.sh /usr/local/bin/render-start
+RUN chmod +x /usr/local/bin/render-start
+
+EXPOSE 10000
+CMD ["/usr/local/bin/render-start"]

--- a/Dockerfile.render
+++ b/Dockerfile.render
@@ -31,7 +31,7 @@ RUN COMPOSER_PROCESS_TIMEOUT=1200 composer install \
     --prefer-dist \
     --no-progress \
     --no-scripts \
-    --optimize-autoloader
+    --no-autoloader
 
 COPY . .
 COPY --from=assets /app/public/build ./public/build

--- a/README.md
+++ b/README.md
@@ -1,12 +1,32 @@
-<p align="center">
-  <img src="docs/social-preview.png" alt="Laravel Community Forum" width="100%">
-</p>
+![Laravel Community Forum banner](https://raw.githubusercontent.com/hyltonwalters/laravel-community-forum/deploy/render-demo/docs/social-preview.png)
 
 # Laravel Community Forum
+
+[![Laravel 12 CI](https://github.com/hyltonwalters/laravel-community-forum/actions/workflows/modernization-checkpoint.yml/badge.svg?branch=deploy%2Frender-demo)](https://github.com/hyltonwalters/laravel-community-forum/actions/workflows/modernization-checkpoint.yml?query=branch%3Adeploy%2Frender-demo)
 
 A Laravel community forum with channels, discussions, replies, likes, watchers, best-answer workflows, notifications and social authentication.
 
 Originally built on Laravel 7, this project has been deliberately modernized and security-hardened through successive framework upgrades to **Laravel 12**. The goal of the modernization work is to preserve the original forum domain while improving authorization, mutation safety, dependency health, automated testing and build reproducibility.
+
+## Live demo
+
+- **Live application:** https://laravel-community-forum.onrender.com
+- **Source:** https://github.com/hyltonwalters/laravel-community-forum
+- **Hosting:** Render
+- **Database:** Neon PostgreSQL
+
+### Demo login
+
+Use the non-admin demo account:
+
+```text
+Email: john@doe.com
+Password: password
+```
+
+The public deployment is intended as a portfolio demonstration of the forum workflow and modernization work. The hosted database is seeded with sample discussions, replies, channels and users so the application can be explored without creating an account first.
+
+> **Note:** Render free services can sleep when idle, so the first request after a period of inactivity may take longer than normal.
 
 ## Modernization highlights
 
@@ -18,13 +38,16 @@ Originally built on Laravel 7, this project has been deliberately modernized and
 - Made likes and discussion watchers idempotent and backed them with database uniqueness constraints.
 - Added transactional handling for reply points, best-answer points and watcher notifications.
 - Replaced the legacy Markdown package with CommonMark 2 and added regression coverage for unsafe raw HTML.
-- Added GitHub Actions verification for dependency audits, Laravel tests and the production frontend build.
+- Added GitHub Actions verification for dependency audits, Laravel tests, the production frontend build and the deployment Docker image.
+- Added a containerized Render deployment backed by Neon PostgreSQL.
 
 ## Current stack
 
 **Backend:** PHP 8.2+, Laravel 12, Eloquent ORM, Laravel Socialite, CommonMark 2  
 **Frontend:** Vite, Bootstrap 5, Sass  
-**Testing:** PHPUnit 11, Laravel feature tests, SQLite in-memory test database  
+**Database:** PostgreSQL on Neon for the hosted demo; SQLite in-memory for automated tests  
+**Deployment:** Docker, Render  
+**Testing:** PHPUnit 11, Laravel feature tests  
 **Quality:** Composer validation/audit, npm audit, production asset build, GitHub Actions CI
 
 ## Forum capabilities
@@ -51,6 +74,7 @@ composer audit --locked
 php artisan test
 npm audit --audit-level=high
 npm run build
+docker build --pull -f Dockerfile.render -t laravel-community-forum-render .
 ```
 
 ## Local setup

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Channel;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
@@ -25,6 +26,8 @@ class AppServiceProvider extends ServiceProvider
    */
   public function boot()
   {
+    Paginator::useBootstrapFive();
+
     View::composer('*', function ($view) {
       $view->with('channels', Channel::all());
     });

--- a/deploy/render-start.sh
+++ b/deploy/render-start.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+: "${PORT:=10000}"
+
+php artisan config:clear
+php artisan migrate --force
+
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+exit(App\User::query()->exists() ? 0 : 1);
+' || php artisan db:seed --force
+
+php artisan view:clear
+php artisan route:clear
+php artisan config:cache
+
+exec php artisan serve --host=0.0.0.0 --port="$PORT"


### PR DESCRIPTION
Adds the production Render deployment path for the Laravel 12 Community Forum, including the Docker image, Render startup script, PostgreSQL support for Neon, deployment CI, live-demo documentation, and Bootstrap 5 pagination configuration.

Validated on deploy/render-demo with passing application tests, frontend production build, dependency audits, and Render image build.